### PR TITLE
add node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist/
+node_modules/


### PR DESCRIPTION
Should skip entire `node_modules` folder from commits...
Once `node_modules` is in `.gitignore`, you can delete the `node_modules` folder from the repo.